### PR TITLE
Fix a few minor issues with ONBUILD variants

### DIFF
--- a/3.10.0/onbuild/Dockerfile
+++ b/3.10.0/onbuild/Dockerfile
@@ -2,11 +2,10 @@ FROM mono:3.10.0
 
 MAINTAINER Jo Shields <jo.shields@xamarin.com>
 
-RUN mkdir -p /usr/src/app/{source,build}
+RUN mkdir -p /usr/src/app/source /usr/src/app/build
 WORKDIR /usr/src/app/source
 
-ONBUILD ADD . /usr/src/app/source
+ONBUILD COPY . /usr/src/app/source
 ONBUILD RUN nuget restore -NonInteractive
 ONBUILD RUN xbuild /property:Configuration=Release /property:OutDir=/usr/src/app/build/
-ONBUILD RUN rm -rf /usr/src/app/source
 ONBUILD WORKDIR /usr/src/app/build

--- a/3.12.0/onbuild/Dockerfile
+++ b/3.12.0/onbuild/Dockerfile
@@ -2,11 +2,10 @@ FROM mono:3.12.0
 
 MAINTAINER Jo Shields <jo.shields@xamarin.com>
 
-RUN mkdir -p /usr/src/app/{source,build}
+RUN mkdir -p /usr/src/app/source /usr/src/app/build
 WORKDIR /usr/src/app/source
 
-ONBUILD ADD . /usr/src/app/source
+ONBUILD COPY . /usr/src/app/source
 ONBUILD RUN nuget restore -NonInteractive
 ONBUILD RUN xbuild /property:Configuration=Release /property:OutDir=/usr/src/app/build/
-ONBUILD RUN rm -rf /usr/src/app/source
 ONBUILD WORKDIR /usr/src/app/build

--- a/3.8.0/onbuild/Dockerfile
+++ b/3.8.0/onbuild/Dockerfile
@@ -2,11 +2,10 @@ FROM mono:3.8.0
 
 MAINTAINER Jo Shields <jo.shields@xamarin.com>
 
-RUN mkdir -p /usr/src/app/{source,build}
+RUN mkdir -p /usr/src/app/source /usr/src/app/build
 WORKDIR /usr/src/app/source
 
-ONBUILD ADD . /usr/src/app/source
+ONBUILD COPY . /usr/src/app/source
 ONBUILD RUN nuget restore -NonInteractive
 ONBUILD RUN xbuild /property:Configuration=Release /property:OutDir=/usr/src/app/build/
-ONBUILD RUN rm -rf /usr/src/app/source
 ONBUILD WORKDIR /usr/src/app/build


### PR DESCRIPTION
```console
$ docker run -it --rm mono:onbuild ls -lAFh /usr/src/app/
drwxr-xr-x 1 root root 0 Jan 14 21:09 source/
drwxr-xr-x 1 root root 0 Jan  1 07:44 {source,build}/
```

Also, we don't save any space by removing /usr/src/app/source since it's already baked into a layer of the image, so we might as well just leave it.