### PR TITLE
Add generate-stackbrew-library.sh script for updating library/mono in an automated way

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+declare -A aliases
+aliases=(
+	[3.12.0]='3.12 3 latest'
+	[3.10.0]='3.10'
+	[3.8.0]='3.8'
+)
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+versions=( */ )
+versions=( "${versions[@]%/}" )
+url='git://github.com/mono/docker'
+
+echo '# maintainer: Jo Shields <jo.shields@xamarin.com> (@directhex)'
+
+for version in "${versions[@]}"; do
+	commit="$(git log -1 --format='format:%H' -- "$version")"
+	versionAliases=( $version ${aliases[$version]} )
+	
+	echo
+	for va in "${versionAliases[@]}"; do
+		echo "$va: ${url}@${commit} $version"
+	done
+	
+	for variant in onbuild; do
+		commit="$(git log -1 --format='format:%H' -- "$version/$variant")"
+		echo
+		for va in "${versionAliases[@]}"; do
+			if [ "$va" = 'latest' ]; then
+				va="$variant"
+			else
+				va="$va-$variant"
+			fi
+			echo "$va: ${url}@${commit} $version/$variant"
+		done
+	done
+done


### PR DESCRIPTION
Here's some example output:
```console
$ ./generate-stackbrew-library.sh
# maintainer: Jo Shields <jo.shields@xamarin.com> (@directhex)

3.10.0: git://github.com/mono/docker@96aca22c58df59c08d345cbe8af79c11b43c5f1f 3.10.0
3.10: git://github.com/mono/docker@96aca22c58df59c08d345cbe8af79c11b43c5f1f 3.10.0

3.10.0-onbuild: git://github.com/mono/docker@6ef5db661a64ae5f50748718467b47facfc80f13 3.10.0/onbuild
3.10-onbuild: git://github.com/mono/docker@6ef5db661a64ae5f50748718467b47facfc80f13 3.10.0/onbuild

3.12.0: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0
3.12: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0
3: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0
latest: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0

3.12.0-onbuild: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0/onbuild
3.12-onbuild: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0/onbuild
3-onbuild: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0/onbuild
onbuild: git://github.com/mono/docker@b7fd8e1775026621ab40d620ed384b9796cfb863 3.12.0/onbuild

3.8.0: git://github.com/mono/docker@96aca22c58df59c08d345cbe8af79c11b43c5f1f 3.8.0
3.8: git://github.com/mono/docker@96aca22c58df59c08d345cbe8af79c11b43c5f1f 3.8.0

3.8.0-onbuild: git://github.com/mono/docker@6ef5db661a64ae5f50748718467b47facfc80f13 3.8.0/onbuild
3.8-onbuild: git://github.com/mono/docker@6ef5db661a64ae5f50748718467b47facfc80f13 3.8.0/onbuild
```

We usually do something like `./generate-stackbrew-library.sh > ../official-images/library/mono` and then commit and PR the result. :+1: