### PR TITLE
remove machine flag from mozroots invocation

### DIFF
--- a/3.12.0/Dockerfile
+++ b/3.12.0/Dockerfile
@@ -15,5 +15,5 @@ RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12
 	&& apt-get install -y mono-devel fsharp mono-vbnc nuget \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN mozroots --machine --import --sync --quiet
+RUN mozroots --import --sync --quiet
 


### PR DESCRIPTION
Hey @directhex, I found this when mucking with the downstream [aspnet nightly](https://github.com/aspnet/aspnet-docker) image, `kpm restore` fails because of cert crap and web request.

This is shotgun-debugging, but it fixes the problem.

/cc @akoeplinger