### PR TITLE
export MONO_VERSION as an environment variable

### DIFF
--- a/4.6.2.7/Dockerfile
+++ b/4.6.2.7/Dockerfile
@@ -4,13 +4,15 @@ MAINTAINER Jo Shields <jo.shields@xamarin.com>
 
 #based on dockerfile by Michael Friis <friism@gmail.com>
 
+ENV MONO_VERSION 4.6.2.7
+
 RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/*
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
-RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.6.2.7 main" > /etc/apt/sources.list.d/mono-xamarin.list \
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-xamarin.list \
   && apt-get update \
   && apt-get install -y binutils mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
   && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
I collect metadata on services in a polyglot environment.  A few services run in Mono.  I'd like to be able to get the version of Mono by [inspecting the image](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/inspect-an-image).    This works fine for JVM services (JAVA_VERSION), Node.js services (NODE_VERSION) and .Net core services (DOTNET_SDK_VERSION).  There is no such environment for Mono and I think it would be nice to have one.