### PR TITLE
Bump to mono 5.0.1.1

### DIFF
--- a/5.0.1.1/Dockerfile
+++ b/5.0.1.1/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # MAINTAINER Jo Shields <jo.shields@xamarin.com>
 # MAINTAINER Alexander Köplinger <alkpli@microsoft.com>
 
 # based on dockerfile by Michael Friis <friism@gmail.com>
 
-ENV MONO_VERSION 5.0.0.100
+ENV MONO_VERSION 5.0.1.1
 
 RUN apt-get update \
   && apt-get install -y curl \


### PR DESCRIPTION
I'm proposing this image bump to the current stable release.

Also proposing a switch to jessie-slim to reduce image size.