### PR TITLE
Swap arm64v8 exclusion to be based on "wheezy" rather than specific versions

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -58,7 +58,7 @@ for version in "${versions[@]}"; do
 		tags="${tags%, }"
 
 		architectures="amd64, i386, arm32v7"
-		if [[ "$version" != "3"* ]]; then architectures+=", arm64v8"; fi
+		if ! grep -q 'wheezy' "$version/Dockerfile"; then architectures+=", arm64v8"; fi
 
 		echo
 		echo "Tags: $tags"


### PR DESCRIPTION
This updates `generate-stackbrew-library.sh` to exclude `arm64v8` based on whether or not `$version/Dockerfile` contains `wheezy` instead of being based on specific versions of mono (since 4.x is also based on Wheezy, and thus cannot support arm64v8).