### PR TITLE
Remove arm32v7 from 3.x as well

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -57,7 +57,8 @@ for version in "${versions[@]}"; do
 		done
 		tags="${tags%, }"
 
-		architectures="amd64, i386, arm32v7"
+		architectures="amd64, i386"
+		if [[ "$version" != "3"* ]]; then architectures+=", arm32v7"; fi
 		if [[ "$version" != "3"* ]] && [[ "$version" != "4"* ]]; then architectures+=", arm64v8"; fi
 
 		echo


### PR DESCRIPTION
See http://download.mono-project.com/repo/debian/dists/312-security/Release, specifically:

> `Architectures: amd64 i386`

Hopefully this is the last one. :innocent: