### PR TITLE
Add support for debian stretch (latest stable) to docker mono

### DIFF
--- a/5.14.0.177/stretch-slim/Dockerfile
+++ b/5.14.0.177/stretch-slim/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:stretch-slim
+
+# MAINTAINER Jo Shields <jo.shields@xamarin.com>
+# MAINTAINER Alexander Köplinger <alkpli@microsoft.com>
+
+ENV MONO_VERSION 5.14.0.177
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+RUN echo "deb http://download.mono-project.com/repo/debian stable-stretch/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list \
+  && apt-get update \
+  && apt-get install -y mono-runtime \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+

--- a/5.14.0.177/stretch/Dockerfile
+++ b/5.14.0.177/stretch/Dockerfile
@@ -1,0 +1,8 @@
+FROM mono:5.14.0.177-stretch
+
+# MAINTAINER Jo Shields <jo.shields@xamarin.com>
+# MAINTAINER Alexander Köplinger <alkpli@microsoft.com>
+
+RUN apt-get update \
+  && apt-get install -y binutils curl mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
+  && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ to latest Mono releases as soon as they're available.
 
 Starting with Mono 5.2 we provide a `slim` variant which only contains the bare minimum to run a simple console app. You can use this as a base and add just what you need.
 
+In addition, later versions of 5.14 will have a debian `stretch` variant as it is now the current stable version of debian. Stretch will take over as the base in the next major mono release.
+
 ## How to use this image
 
 This image can be used to run stand-alone Mono console apps or build your projects in a container.

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -33,6 +33,14 @@ for version in "${versions[@]}"; do
 		variants+=('-slim')
 	fi
 
+	if [ -d $version/stretch ]; then
+		variants+=('-stretch')
+	fi
+
+	if [ -d $version/stretch-slim ]; then
+		variants+=('-stretch-slim')
+	fi
+
 	for variant in "${variants[@]}"; do
 		commit="$(git log -1 --format='format:%H' -- "$version${variant/-//}")"
 		versionAliases=( $version )


### PR DESCRIPTION
I'm really not sure if this is the right way to do it, but I wanted to add a stretch variant to the base images, so #68 can be handled until there's a new major version of mono.

jessie is getting pretty old and its hard to install extra needed packages now.

Let me know if its not the right way/needs changes/etc etc etc